### PR TITLE
List end point implementation

### DIFF
--- a/gateway/api/models.py
+++ b/gateway/api/models.py
@@ -8,7 +8,9 @@ from django.core.validators import FileExtensionValidator
 from django.db import models
 from django_prometheus.models import ExportModelOperationsMixin
 
-from api.permissions import RUN_PROGRAM_PERMISSION
+
+VIEW_PROGRAM_PERMISSION = "view_program"
+RUN_PROGRAM_PERMISSION = "run_program"
 
 
 def get_upload_path(instance, filename):

--- a/gateway/api/models.py
+++ b/gateway/api/models.py
@@ -8,6 +8,8 @@ from django.core.validators import FileExtensionValidator
 from django.db import models
 from django_prometheus.models import ExportModelOperationsMixin
 
+from api.permissions import RUN_PROGRAM_PERMISSION
+
 
 def get_upload_path(instance, filename):
     """Returns save path for artifacts."""
@@ -75,7 +77,7 @@ class Program(ExportModelOperationsMixin("program"), models.Model):
     )
 
     class Meta:
-        permissions = (("run_program", "Can run function"),)
+        permissions = ((RUN_PROGRAM_PERMISSION, "Can run function"),)
 
     def __str__(self):
         return f"{self.title}"

--- a/gateway/api/models_proxies.py
+++ b/gateway/api/models_proxies.py
@@ -7,7 +7,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 
-from api.permissions import VIEW_PROGRAM_PERMISSION
+from api.models import VIEW_PROGRAM_PERMISSION
 from api.utils import safe_request, remove_duplicates_from_list
 
 

--- a/gateway/api/models_proxies.py
+++ b/gateway/api/models_proxies.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group, Permission
 
+from api.permissions import VIEW_PROGRAM_PERMISSION
 from api.utils import safe_request, remove_duplicates_from_list
 
 
@@ -103,7 +104,7 @@ class QuantumUserProxy(get_user_model()):  # pylint: disable=too-few-public-meth
         self.groups.clear()
 
         logger.info("Update [%s] groups", len(unique_instances))
-        view_program = Permission.objects.get(codename="view_program")
+        view_program = Permission.objects.get(codename=VIEW_PROGRAM_PERMISSION)
         for instance in unique_instances:
             group, created = Group.objects.get_or_create(name=instance)
             if created:

--- a/gateway/api/permissions.py
+++ b/gateway/api/permissions.py
@@ -4,6 +4,11 @@ from rest_framework import permissions
 from api.models import RuntimeJob
 
 
+# Program permissions
+VIEW_PROGRAM_PERMISSION = "view_program"
+RUN_PROGRAM_PERMISSION = "run_program"
+
+
 class IsOwner(permissions.BasePermission):
     """
     Custom permission to only allow owners of an object to edit it.

--- a/gateway/api/permissions.py
+++ b/gateway/api/permissions.py
@@ -4,11 +4,6 @@ from rest_framework import permissions
 from api.models import RuntimeJob
 
 
-# Program permissions
-VIEW_PROGRAM_PERMISSION = "view_program"
-RUN_PROGRAM_PERMISSION = "run_program"
-
-
 class IsOwner(permissions.BasePermission):
     """
     Custom permission to only allow owners of an object to edit it.

--- a/gateway/api/v1/views.py
+++ b/gateway/api/v1/views.py
@@ -8,7 +8,7 @@ from rest_framework.decorators import action
 
 
 from api import views
-from api.models import Program, Job, RuntimeJob
+from api.models import Job, RuntimeJob
 from api.permissions import IsOwner
 from . import serializers as v1_serializers
 
@@ -18,8 +18,8 @@ class ProgramViewSet(views.ProgramViewSet):  # pylint: disable=too-many-ancestor
     Quantum function view set first version. Use ProgramSerializer V1.
     """
 
-    queryset = Program.objects.all()
     serializer_class = v1_serializers.ProgramSerializer
+    pagination_class = None
     permission_classes = [permissions.IsAuthenticated]
 
     @staticmethod
@@ -46,8 +46,12 @@ class ProgramViewSet(views.ProgramViewSet):  # pylint: disable=too-many-ancestor
     def get_model_serializer_run_program(*args, **kwargs):
         return v1_serializers.RunProgramModelSerializer(*args, **kwargs)
 
-    def get_serializer_class(self):
-        return v1_serializers.ProgramSerializer
+    @swagger_auto_schema(
+        operation_description="List author Qiskit Patterns",
+        responses={status.HTTP_200_OK: v1_serializers.ProgramSerializer(many=True)},
+    )
+    def list(self, request):
+        return super().list(request)
 
     @swagger_auto_schema(
         operation_description="Upload a Qiskit Pattern",

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -122,6 +122,7 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
     def get_queryset(self):
         author = self.request.user
 
+        logger.info("ProgramViewSet get view_program permission")
         view_program_permission = Permission.objects.get(
             codename=VIEW_PROGRAM_PERMISSION
         )
@@ -129,12 +130,14 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
         user_criteria = Q(user=author)
         author_criteria = Q(author=author)
         view_permission_criteria = Q(permissions=view_program_permission)
+        logger.info("ProgramViewSet get author groups with view permissions")
         author_groups_with_view_permissions = Group.objects.filter(
             user_criteria & view_permission_criteria
         )
         author_groups_with_view_permissions_criteria = Q(
             instances__in=author_groups_with_view_permissions
         )
+        logger.info("ProgramViewSet get programs for authenticated user")
         return Program.objects.filter(
             author_criteria | author_groups_with_view_permissions_criteria
         ).distinct()

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -31,8 +31,7 @@ from rest_framework.generics import get_object_or_404
 from rest_framework.response import Response
 from utils import sanitize_file_path
 
-from .models import Program, Job, RuntimeJob
-from .permissions import VIEW_PROGRAM_PERMISSION
+from .models import VIEW_PROGRAM_PERMISSION, Program, Job, RuntimeJob
 from .ray import get_job_handler
 from .serializers import (
     JobConfigSerializer,
@@ -119,7 +118,6 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
 
     def get_object(self):
         logger.warning("ProgramViewSet.get_object not implemented")
-        return None
 
     def get_queryset(self):
         author = self.request.user

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -127,20 +127,43 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
             codename=VIEW_PROGRAM_PERMISSION
         )
 
+        # Groups logic
         user_criteria = Q(user=author)
         author_criteria = Q(author=author)
         view_permission_criteria = Q(permissions=view_program_permission)
-        logger.info("ProgramViewSet get author groups with view permissions")
         author_groups_with_view_permissions = Group.objects.filter(
             user_criteria & view_permission_criteria
         )
+        author_groups_with_view_permissions_count = Group.objects.filter(
+            user_criteria & view_permission_criteria
+        ).count()
+        logger.info(
+            "ProgramViewSet get author[%s] groups [%s]",
+            author.id,
+            author_groups_with_view_permissions_count,
+        )
+
+        # Programs logic
         author_groups_with_view_permissions_criteria = Q(
             instances__in=author_groups_with_view_permissions
         )
-        logger.info("ProgramViewSet get programs for authenticated user")
-        return Program.objects.filter(
+        author_programs = Program.objects.filter(
             author_criteria | author_groups_with_view_permissions_criteria
         ).distinct()
+        author_programs_count = (
+            Program.objects.filter(
+                author_criteria | author_groups_with_view_permissions_criteria
+            )
+            .distinct()
+            .count()
+        )
+        logger.info(
+            "ProgramViewSet get author[%s] programs[%s]",
+            author.id,
+            author_programs_count,
+        )
+
+        return author_programs
 
     def list(self, request):
         """List programs:"""

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -129,14 +129,13 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
 
         # Groups logic
         user_criteria = Q(user=author)
-        author_criteria = Q(author=author)
         view_permission_criteria = Q(permissions=view_program_permission)
         author_groups_with_view_permissions = Group.objects.filter(
             user_criteria & view_permission_criteria
         )
-        author_groups_with_view_permissions_count = Group.objects.filter(
-            user_criteria & view_permission_criteria
-        ).count()
+        author_groups_with_view_permissions_count = (
+            author_groups_with_view_permissions.count()
+        )
         logger.info(
             "ProgramViewSet get author[%s] groups [%s]",
             author.id,
@@ -144,19 +143,14 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
         )
 
         # Programs logic
+        author_criteria = Q(author=author)
         author_groups_with_view_permissions_criteria = Q(
             instances__in=author_groups_with_view_permissions
         )
         author_programs = Program.objects.filter(
             author_criteria | author_groups_with_view_permissions_criteria
         ).distinct()
-        author_programs_count = (
-            Program.objects.filter(
-                author_criteria | author_groups_with_view_permissions_criteria
-            )
-            .distinct()
-            .count()
-        )
+        author_programs_count = author_programs.count()
         logger.info(
             "ProgramViewSet get author[%s] programs[%s]",
             author.id,

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -124,7 +124,9 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
     def get_queryset(self):
         author = self.request.user
 
-        view_program_permission = Permission.objects.get(codename=VIEW_PROGRAM_PERMISSION)
+        view_program_permission = Permission.objects.get(
+            codename=VIEW_PROGRAM_PERMISSION
+        )
 
         user_criteria = Q(user=author)
         author_criteria = Q(author=author)
@@ -139,7 +141,6 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
             author_criteria | author_groups_with_view_permissions_criteria
         ).distinct()
 
-
     def list(self, request):
         """List programs:"""
         tracer = trace.get_tracer("gateway.tracer")
@@ -148,7 +149,6 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
             serializer = self.get_serializer(self.get_queryset(), many=True)
 
         return Response(serializer.data)
-        
 
     @action(methods=["POST"], detail=False)
     def upload(self, request):

--- a/gateway/tests/api/test_models_proxies.py
+++ b/gateway/tests/api/test_models_proxies.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 from api.models import Program
 from api.models_proxies import QuantumUserProxy
+from api.permissions import VIEW_PROGRAM_PERMISSION
 
 
 class ProxiesTest(APITestCase):
@@ -43,7 +44,7 @@ class ProxiesTest(APITestCase):
 
     def test_query_to_view_test_user_programs(self):
         groups_id_for_view = [100, 101, 102, 103, 104]
-        view_program_permission = Permission.objects.get(codename="view_program")
+        view_program_permission = Permission.objects.get(codename=VIEW_PROGRAM_PERMISSION)
 
         # We give view permission to all groups
         for group_id_to_view in groups_id_for_view:
@@ -79,7 +80,7 @@ class ProxiesTest(APITestCase):
 
     def test_query_to_view_test_user_2_programs(self):
         groups_id_for_view = [100, 101, 102, 103, 104]
-        view_program_permission = Permission.objects.get(codename="view_program")
+        view_program_permission = Permission.objects.get(codename=VIEW_PROGRAM_PERMISSION)
 
         # We give view permission to all groups
         for group_id_to_view in groups_id_for_view:

--- a/gateway/tests/api/test_models_proxies.py
+++ b/gateway/tests/api/test_models_proxies.py
@@ -44,7 +44,9 @@ class ProxiesTest(APITestCase):
 
     def test_query_to_view_test_user_programs(self):
         groups_id_for_view = [100, 101, 102, 103, 104]
-        view_program_permission = Permission.objects.get(codename=VIEW_PROGRAM_PERMISSION)
+        view_program_permission = Permission.objects.get(
+            codename=VIEW_PROGRAM_PERMISSION
+        )
 
         # We give view permission to all groups
         for group_id_to_view in groups_id_for_view:
@@ -80,7 +82,9 @@ class ProxiesTest(APITestCase):
 
     def test_query_to_view_test_user_2_programs(self):
         groups_id_for_view = [100, 101, 102, 103, 104]
-        view_program_permission = Permission.objects.get(codename=VIEW_PROGRAM_PERMISSION)
+        view_program_permission = Permission.objects.get(
+            codename=VIEW_PROGRAM_PERMISSION
+        )
 
         # We give view permission to all groups
         for group_id_to_view in groups_id_for_view:

--- a/gateway/tests/api/test_models_proxies.py
+++ b/gateway/tests/api/test_models_proxies.py
@@ -60,7 +60,7 @@ class ProxiesTest(APITestCase):
         titles_from_response = []
         for program in response.data:
             titles_from_response.append(program["title"])
-        
+
         programs_to_test = ["Public program", "Private program", "My program"]
         self.assertListEqual(titles_from_response, programs_to_test)
 

--- a/gateway/tests/api/test_models_proxies.py
+++ b/gateway/tests/api/test_models_proxies.py
@@ -5,9 +5,8 @@ from django.db.models import Q
 from rest_framework.test import APITestCase
 from unittest.mock import MagicMock, patch
 
-from api.models import Program
+from api.models import VIEW_PROGRAM_PERMISSION, Program
 from api.models_proxies import QuantumUserProxy
-from api.permissions import VIEW_PROGRAM_PERMISSION
 
 
 class ProxiesTest(APITestCase):

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -32,27 +32,11 @@ class TestProgramApi(APITestCase):
         programs_response = self.client.get(reverse("v1:programs-list"), format="json")
 
         self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
-        self.assertEqual(programs_response.data.get("count"), 1)
+        self.assertEqual(len(programs_response.data), 1)
         self.assertEqual(
-            programs_response.data.get("results")[0].get("title"),
+            programs_response.data[0].get("title"),
             "Program",
         )
-
-    def test_program_detail(self):
-        """Tests program detail authorized."""
-
-        user = models.User.objects.get(username="test_user")
-        self.client.force_authenticate(user=user)
-        programs_response = self.client.get(
-            reverse(
-                "v1:programs-detail",
-                args=["1a7947f9-6ae8-4e3d-ac1e-e7d608deec82"],
-            ),
-            format="json",
-        )
-        self.assertEqual(programs_response.status_code, status.HTTP_200_OK)
-        self.assertEqual(programs_response.data.get("title"), "Program")
-        self.assertEqual(programs_response.data.get("entrypoint"), "program.py")
 
     def test_run_existing(self):
         """Tests run existing authorized."""


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Close #1305 

This PR integrates ACL in the list end-point. So now we are going to be able not only our Qiskit Functions if not other Qiskit Functions that we can have access.

### Details and comments

- Use of `GenericViewSet` instead of `ModelViewSet` in `Programs`
- Added `list` end-point to the `ViewSet`
- Modified the `queryset` to include the new implementation for ACL