### PR TITLE
Get end point

### DIFF
--- a/client/quantum_serverless/core/client.py
+++ b/client/quantum_serverless/core/client.py
@@ -357,6 +357,10 @@ class BaseClient(JsonSerializable):
     def list(self, **kwargs) -> List[QiskitFunction]:
         """Returns list of available programs."""
         raise NotImplementedError
+    
+    def get(self, title) -> QiskitFunction:
+        """Returns a specific program by title."""
+        raise NotImplementedError
 
 
 class BaseProvider(BaseClient):
@@ -480,9 +484,13 @@ class ServerlessClient(BaseClient):
     def file_upload(self, file: str):
         return self._files_client.upload(file)
 
-    def list(self, **kwargs) -> List[QiskitFunction]:
+    def list(self) -> List[QiskitFunction]:
         """Returns list of available programs."""
-        return self._job_client.get_programs(**kwargs)
+        return self._job_client.get_programs()
+    
+    def get(self, title) -> QiskitFunction:
+        """Returns a specific program by title."""
+        return self._job_client.get_program(title)
 
     def _verify_token(self, token: str):
         """Verify token."""

--- a/client/quantum_serverless/core/client.py
+++ b/client/quantum_serverless/core/client.py
@@ -354,10 +354,10 @@ class BaseClient(JsonSerializable):
         )
         return self.list(**kwargs)
 
-    def list(self, **kwargs) -> List[QiskitFunction]:
+    def list(self) -> List[QiskitFunction]:
         """Returns list of available programs."""
         raise NotImplementedError
-    
+
     def get(self, title) -> QiskitFunction:
         """Returns a specific program by title."""
         raise NotImplementedError
@@ -487,7 +487,7 @@ class ServerlessClient(BaseClient):
     def list(self) -> List[QiskitFunction]:
         """Returns list of available programs."""
         return self._job_client.get_programs()
-    
+
     def get(self, title) -> QiskitFunction:
         """Returns a specific program by title."""
         return self._job_client.get_program(title)

--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -659,22 +659,32 @@ class GatewayJobClient(BaseJobClient):
             for job in response_data.get("results", [])
         ]
 
-    def get_programs(self, **kwargs):
+    def get_programs(self):
         tracer = trace.get_tracer("client.tracer")
         with tracer.start_as_current_span("program.list"):
-            limit = kwargs.get("limit", 10)
-            offset = kwargs.get("offset", 0)
             response_data = safe_json_request(
                 request=lambda: requests.get(
-                    f"{self.host}/api/{self.version}/programs/?limit={limit}&offset={offset}",
+                    f"{self.host}/api/{self.version}/programs",
                     headers={"Authorization": f"Bearer {self._token}"},
                     timeout=REQUESTS_TIMEOUT,
                 )
             )
         return [
             QiskitFunction(program.get("title"), raw_data=program, job_client=self)
-            for program in response_data.get("results", [])
+            for program in response_data
         ]
+    
+    def get_program(self, title):
+        tracer = trace.get_tracer("client.tracer")
+        with tracer.start_as_current_span("program.get"):
+            response_data = safe_json_request(
+                request=lambda: requests.get(
+                    f"{self.host}/api/{self.version}/programs/{title}",
+                    headers={"Authorization": f"Bearer {self._token}"},
+                    timeout=REQUESTS_TIMEOUT,
+                )
+            )
+        return QiskitFunction(response_data.get("title"), raw_data=response_data, job_client=self)
 
 
 class Job:

--- a/client/quantum_serverless/core/job.py
+++ b/client/quantum_serverless/core/job.py
@@ -146,8 +146,12 @@ class BaseJobClient:
         """Return results."""
         raise NotImplementedError
 
-    def get_programs(self, **kwargs):
+    def get_programs(self):
         """Returns list of programs."""
+        raise NotImplementedError
+
+    def get_program(self, title):
+        """Returns a specific program by title."""
         raise NotImplementedError
 
 
@@ -363,7 +367,7 @@ class LocalJobClient(BaseJobClient):
         self._jobs[job.job_id] = entry
         return job
 
-    def get_programs(self, **kwargs):
+    def get_programs(self):
         """Returns list of programs."""
         return self._patterns
 
@@ -673,7 +677,7 @@ class GatewayJobClient(BaseJobClient):
             QiskitFunction(program.get("title"), raw_data=program, job_client=self)
             for program in response_data
         ]
-    
+
     def get_program(self, title):
         tracer = trace.get_tracer("client.tracer")
         with tracer.start_as_current_span("program.get"):
@@ -684,7 +688,9 @@ class GatewayJobClient(BaseJobClient):
                     timeout=REQUESTS_TIMEOUT,
                 )
             )
-        return QiskitFunction(response_data.get("title"), raw_data=response_data, job_client=self)
+        return QiskitFunction(
+            response_data.get("title"), raw_data=response_data, job_client=self
+        )
 
 
 class Job:

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -25,16 +25,6 @@ class UploadProgramSerializer(serializers.ModelSerializer):
     class Meta:
         model = Program
 
-    def retrieve_one_by_title(self, title, author):
-        """
-        This method returns a Program entry if it finds an entry searching by the title, if not None
-        """
-        return (
-            Program.objects.filter(title=title, author=author)
-            .order_by("-created")
-            .first()
-        )
-
     def create(self, validated_data):
         title = validated_data.get("title")
         logger.info("Creating program [%s] with UploadProgramSerializer", title)

--- a/gateway/api/serializers.py
+++ b/gateway/api/serializers.py
@@ -111,16 +111,6 @@ class RunExistingProgramSerializer(serializers.Serializer):
     arguments = serializers.CharField()
     config = serializers.JSONField()
 
-    def retrieve_one_by_title(self, title, author):
-        """
-        This method returns a Program entry if it finds an entry searching by the title, if not None
-        """
-        return (
-            Program.objects.filter(title=title, author=author)
-            .order_by("-created")
-            .first()
-        )
-
     def update(self, instance, validated_data):
         pass
 
@@ -199,16 +189,6 @@ class RunProgramSerializer(serializers.Serializer):
         representation = super().to_representation(instance)
         representation["config"] = json.loads(representation["config"])
         return representation
-
-    def retrieve_one_by_title(self, title, author):
-        """
-        This method returns a Program entry if it finds an entry searching by the title, if not None
-        """
-        return (
-            Program.objects.filter(title=title, author=author)
-            .order_by("-created")
-            .first()
-        )
 
     def create(self, validated_data):
         pass

--- a/gateway/api/v1/views.py
+++ b/gateway/api/v1/views.py
@@ -19,6 +19,7 @@ class ProgramViewSet(views.ProgramViewSet):  # pylint: disable=too-many-ancestor
     """
 
     serializer_class = v1_serializers.ProgramSerializer
+    lookup_field = "title"
     pagination_class = None
     permission_classes = [permissions.IsAuthenticated]
 
@@ -45,6 +46,13 @@ class ProgramViewSet(views.ProgramViewSet):  # pylint: disable=too-many-ancestor
     @staticmethod
     def get_model_serializer_run_program(*args, **kwargs):
         return v1_serializers.RunProgramModelSerializer(*args, **kwargs)
+
+    @swagger_auto_schema(
+        operation_description="Get a specific Qiskit Patterns",
+        responses={status.HTTP_200_OK: v1_serializers.ProgramSerializer(many=False)},
+    )
+    def retrieve(self, request, title=None):
+        return super().retrieve(request, title)
 
     @swagger_auto_schema(
         operation_description="List author Qiskit Patterns",

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -156,6 +156,20 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
 
         return author_program
 
+    def get_owned_object(self):
+        """This method only retrieves programs where the author is the owner"""
+        author = self.request.user
+        title = self.kwargs["title"]
+
+        program = Program.objects.get(title=title, author=author)
+        logger.info(
+            "ProgramViewSet.get_owned_object get author[%s] program [%s]",
+            author.id,
+            title,
+        )
+
+        return program
+
     def get_queryset(self):
         author = self.request.user
 
@@ -246,8 +260,9 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
             author = request.user
             try:
                 self.kwargs["title"] = title
-                program = self.get_object()
+                program = self.get_owned_object()
             except Program.DoesNotExist:
+                logger.info("Program not found. [%s] is going to be created", title)
                 program = None
             if program is not None:
                 logger.info("Program found. [%s] is going to be updated", title)

--- a/gateway/api/views.py
+++ b/gateway/api/views.py
@@ -244,7 +244,11 @@ class ProgramViewSet(viewsets.GenericViewSet):  # pylint: disable=too-many-ances
 
             title = serializer.validated_data.get("title")
             author = request.user
-            program = serializer.retrieve_one_by_title(title=title, author=author)
+            try:
+                self.kwargs["title"] = title
+                program = self.get_object()
+            except Program.DoesNotExist:
+                program = None
             if program is not None:
                 logger.info("Program found. [%s] is going to be updated", title)
                 serializer = self.get_serializer_upload_program(

--- a/gateway/tests/api/test_v1_program.py
+++ b/gateway/tests/api/test_v1_program.py
@@ -23,6 +23,31 @@ class TestProgramApi(APITestCase):
         response = self.client.get(url, format="json")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_programs_retrieve(self):
+        """Tests program retrieve authorized."""
+
+        user = models.User.objects.get(username="test_user")
+        self.client.force_authenticate(user=user)
+
+        program_response = self.client.get(
+            reverse("v1:programs-detail", kwargs={"title": "Program"}), format="json"
+        )
+
+        self.assertEqual(program_response.status_code, status.HTTP_200_OK)
+        self.assertEqual(program_response.data.get("title"), "Program")
+
+    def test_programs_retrieve_404_error(self):
+        """Tests program retrieve authorized."""
+
+        user = models.User.objects.get(username="test_user_2")
+        self.client.force_authenticate(user=user)
+
+        program_response = self.client.get(
+            reverse("v1:programs-detail", kwargs={"title": "Program"}), format="json"
+        )
+
+        self.assertEqual(program_response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_programs_list(self):
         """Tests programs list authorized."""
 


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.

- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary

Close #1314 

This PR introduces `get` end-point to retrieve a Qiskit Function.

### Details and comments

- `retrieve` end-point implemented in Gateway
- remove `retrieve_by_title` method from serializers to use the new `get_object`
  - `upload` method continues only updating owners programs
- add support for the new end-point in client
- fixed a problem with the `list` end-point due to the new ACL logic